### PR TITLE
Format model requests

### DIFF
--- a/src/main/java/es/thalesalv/gptbot/adapters/data/ContextDatastore.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/data/ContextDatastore.java
@@ -6,44 +6,31 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 import es.thalesalv.gptbot.application.config.CommandEventData;
-import es.thalesalv.gptbot.application.config.Persona;
 
 @Component
 public class ContextDatastore {
 
     private ThreadLocal<CommandEventData> commandEventData = new ThreadLocal<>();
-    private ThreadLocal<Persona> persona = new ThreadLocal<>();
-
-    public void setPersona(final Persona persona) {
-        this.persona.set(persona);
-    }
-
-    public Persona getPersona() {
-        return Optional.ofNullable(this.persona)
-        		.map(ThreadLocal::get)
-        		.orElseThrow(() -> new NullPointerException("persona not set on thread"));
-    }
-
-    public boolean isPersonaNull() {
-        return Objects.isNull(persona.get());
-    }
 
     public void setCommandEventData(final CommandEventData commandEventData) {
+
         this.commandEventData.set(commandEventData);
     }
 
     public CommandEventData getCommandEventData() {
+
         return Optional.ofNullable(this.commandEventData)
         		.map(ThreadLocal::get)
         		.orElseThrow(()-> new NullPointerException("commandEventData not set on thread"));
     }
 
     public boolean isCommandEventDataNull() {
+
         return Objects.isNull(commandEventData.get());
     }
 
     public void clearContext() {
-        this.persona.remove();
+
         this.commandEventData.remove();
     }
 }

--- a/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/MessageListener.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/MessageListener.java
@@ -34,10 +34,10 @@ public class MessageListener extends ListenerAdapter {
             botConfig.getPersonas().forEach(persona -> {
                 final boolean isCurrentChannel = persona.getChannelIds().stream().anyMatch(id -> event.getChannel().getId().equals(id));
                 if (isCurrentChannel) {
-                	MessageEventData messageEventData = messageEventDataTranslator.translate(event);
+                	MessageEventData messageEventData = messageEventDataTranslator.translate(event, persona);
                     final GptModelService model = (GptModelService) applicationContext.getBean(persona.getModelFamily() + MODEL_SERVICE);
                     final BotUseCase useCase = (BotUseCase) applicationContext.getBean(persona.getIntent() + USE_CASE);
-                    useCase.generateResponse(persona, messageEventData, event.getMessage().getMentions(), model);
+                    useCase.generateResponse(messageEventData, event.getMessage().getMentions(), model);
                 }
             });
         }

--- a/src/main/java/es/thalesalv/gptbot/application/config/CommandEventData.java
+++ b/src/main/java/es/thalesalv/gptbot/application/config/CommandEventData.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import net.dv8tion.jda.api.entities.SelfUser;
 
 @Getter
 @Setter
@@ -13,5 +14,6 @@ public class CommandEventData {
 
     private UUID lorebookEntryId;
     private UUID lorebookEntryRegexId;
-    private String discordUserId;
+    private SelfUser discordUser;
+    private Persona persona;
 }

--- a/src/main/java/es/thalesalv/gptbot/application/config/MessageEventData.java
+++ b/src/main/java/es/thalesalv/gptbot/application/config/MessageEventData.java
@@ -19,4 +19,5 @@ public class MessageEventData {
     private User messageAuthor;
     private Message message;
     private MessageChannelUnion channel;
+    private Persona persona;
 }

--- a/src/main/java/es/thalesalv/gptbot/application/service/ChatGptModelService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/ChatGptModelService.java
@@ -43,12 +43,13 @@ public class ChatGptModelService implements GptModelService {
         final User author = eventData.getMessageAuthor();
         final Set<LorebookEntry> entriesFound = new HashSet<>();
 
+        lorebookEntryExtractionHelper.handleEntriesMentioned(messages, entriesFound);
         if (eventData.getPersona().getIntent().equals("dungeonMaster")) {
             lorebookEntryExtractionHelper.handlePlayerCharacterEntries(entriesFound, messages, author, mentions);
+            lorebookEntryExtractionHelper.processEntriesFoundForRpg(entriesFound, messages, author.getJDA());
+        } else {
+            lorebookEntryExtractionHelper.processEntriesFoundForChat(entriesFound, messages, author.getJDA());
         }
-
-        lorebookEntryExtractionHelper.handleEntriesMentioned(messages, entriesFound);
-        lorebookEntryExtractionHelper.processEntriesFound(entriesFound, messages, author.getJDA());
 
         final List<ChatGptMessage> chatGptMessages = lorebookEntryExtractionHelper.formatMessagesForChatGpt(entriesFound, messages, eventData);
         final ChatGptRequest request = chatGptRequestTranslator.buildRequest(messages, eventData.getPersona(), chatGptMessages);

--- a/src/main/java/es/thalesalv/gptbot/application/service/ChatGptModelService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/ChatGptModelService.java
@@ -1,27 +1,34 @@
 package es.thalesalv.gptbot.application.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import es.thalesalv.gptbot.adapters.data.db.entity.LorebookEntry;
 import es.thalesalv.gptbot.adapters.rest.OpenAIApiService;
 import es.thalesalv.gptbot.application.config.MessageEventData;
-import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.application.errorhandling.CommonErrorHandler;
+import es.thalesalv.gptbot.application.service.helper.MessageFormatHelper;
 import es.thalesalv.gptbot.application.service.interfaces.GptModelService;
 import es.thalesalv.gptbot.application.translator.ChatGptRequestTranslator;
 import es.thalesalv.gptbot.domain.exception.ModelResponseBlankException;
+import es.thalesalv.gptbot.domain.model.openai.gpt.ChatGptMessage;
 import es.thalesalv.gptbot.domain.model.openai.gpt.ChatGptRequest;
 import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Mentions;
+import net.dv8tion.jda.api.entities.User;
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 public class ChatGptModelService implements GptModelService {
 
+    private final MessageFormatHelper lorebookEntryExtractionHelper;
     private final CommonErrorHandler commonErrorHandler;
     private final ChatGptRequestTranslator chatGptRequestTranslator;
     private final OpenAIApiService openAiService;
@@ -29,11 +36,23 @@ public class ChatGptModelService implements GptModelService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChatGptModelService.class);
 
     @Override
-    public Mono<String> generate(MessageEventData messageEventData, final String prompt, final Persona persona, final List<String> messages) {
+    public Mono<String> generate(final String prompt, final List<String> messages, final MessageEventData eventData) {
 
-        LOGGER.debug("Called inference for ChatGPT. Persona -> {}", persona);
-        final ChatGptRequest request = chatGptRequestTranslator.buildRequest(messages, persona.getModelName(), persona);
-        return openAiService.callGptChatApi(request, messageEventData).map(response -> {
+        LOGGER.debug("Called inference for ChatGPT. Persona -> {}", eventData.getPersona());
+        final Mentions mentions = eventData.getMessage().getMentions();
+        final User author = eventData.getMessageAuthor();
+        final Set<LorebookEntry> entriesFound = new HashSet<>();
+
+        if (eventData.getPersona().getIntent().equals("dungeonMaster")) {
+            lorebookEntryExtractionHelper.handlePlayerCharacterEntries(entriesFound, messages, author, mentions);
+        }
+
+        lorebookEntryExtractionHelper.handleEntriesMentioned(messages, entriesFound);
+        lorebookEntryExtractionHelper.processEntriesFound(entriesFound, messages, author.getJDA());
+
+        final List<ChatGptMessage> chatGptMessages = lorebookEntryExtractionHelper.formatMessagesForChatGpt(entriesFound, messages, eventData);
+        final ChatGptRequest request = chatGptRequestTranslator.buildRequest(messages, eventData.getPersona(), chatGptMessages);
+        return openAiService.callGptChatApi(request, eventData).map(response -> {
             final String responseText = response.getChoices().get(0).getMessage().getContent();
             if (StringUtils.isBlank(responseText)) {
                 throw new ModelResponseBlankException();
@@ -41,6 +60,6 @@ public class ChatGptModelService implements GptModelService {
 
             return responseText.trim();
         })
-        .doOnError(ModelResponseBlankException.class::isInstance, e -> commonErrorHandler.handleEmptyResponse(messageEventData));
+        .doOnError(ModelResponseBlankException.class::isInstance, e -> commonErrorHandler.handleEmptyResponse(eventData));
     }
 }

--- a/src/main/java/es/thalesalv/gptbot/application/service/Gpt3ModelService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/Gpt3ModelService.java
@@ -42,12 +42,13 @@ public class Gpt3ModelService implements GptModelService {
         final User author = eventData.getMessageAuthor();
         final Set<LorebookEntry> entriesFound = new HashSet<>();
 
+        lorebookEntryExtractionHelper.handleEntriesMentioned(messages, entriesFound);
         if (eventData.getPersona().getIntent().equals("dungeonMaster")) {
             lorebookEntryExtractionHelper.handlePlayerCharacterEntries(entriesFound, messages, author, mentions);
+            lorebookEntryExtractionHelper.processEntriesFoundForRpg(entriesFound, messages, author.getJDA());
+        } else {
+            lorebookEntryExtractionHelper.processEntriesFoundForChat(entriesFound, messages, author.getJDA());
         }
-
-        lorebookEntryExtractionHelper.handleEntriesMentioned(messages, entriesFound);
-        lorebookEntryExtractionHelper.processEntriesFound(entriesFound, messages, author.getJDA());
 
         final Gpt3Request request = gptRequestTranslator.buildRequest(prompt, eventData.getPersona());
         return openAiService.callGptApi(request, eventData).map(response -> {

--- a/src/main/java/es/thalesalv/gptbot/application/service/Gpt3ModelService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/Gpt3ModelService.java
@@ -1,27 +1,33 @@
 package es.thalesalv.gptbot.application.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import es.thalesalv.gptbot.adapters.data.db.entity.LorebookEntry;
 import es.thalesalv.gptbot.adapters.rest.OpenAIApiService;
 import es.thalesalv.gptbot.application.config.MessageEventData;
-import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.application.errorhandling.CommonErrorHandler;
+import es.thalesalv.gptbot.application.service.helper.MessageFormatHelper;
 import es.thalesalv.gptbot.application.service.interfaces.GptModelService;
 import es.thalesalv.gptbot.application.translator.Gpt3RequestTranslator;
 import es.thalesalv.gptbot.domain.exception.ModelResponseBlankException;
 import es.thalesalv.gptbot.domain.model.openai.gpt.Gpt3Request;
 import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Mentions;
+import net.dv8tion.jda.api.entities.User;
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 public class Gpt3ModelService implements GptModelService {
 
+    private final MessageFormatHelper lorebookEntryExtractionHelper;
     private final CommonErrorHandler commonErrorHandler;
     private final Gpt3RequestTranslator gptRequestTranslator;
     private final OpenAIApiService openAiService;
@@ -29,11 +35,22 @@ public class Gpt3ModelService implements GptModelService {
     private static final Logger LOGGER = LoggerFactory.getLogger(Gpt3ModelService.class);
 
     @Override
-    public Mono<String> generate(final MessageEventData messageEventData, final String prompt, final Persona persona, final List<String> messages) {
+    public Mono<String> generate(final String prompt, final List<String> messages, final MessageEventData eventData) {
 
-        LOGGER.debug("Called inference for GPT3. Persona -> {}", persona);
-        final Gpt3Request request = gptRequestTranslator.buildRequest(prompt, persona.getModelName(), persona);
-        return openAiService.callGptApi(request, messageEventData).map(response -> {
+        LOGGER.debug("Called inference for GPT3. Persona -> {}", eventData.getPersona());
+        final Mentions mentions = eventData.getMessage().getMentions();
+        final User author = eventData.getMessageAuthor();
+        final Set<LorebookEntry> entriesFound = new HashSet<>();
+
+        if (eventData.getPersona().getIntent().equals("dungeonMaster")) {
+            lorebookEntryExtractionHelper.handlePlayerCharacterEntries(entriesFound, messages, author, mentions);
+        }
+
+        lorebookEntryExtractionHelper.handleEntriesMentioned(messages, entriesFound);
+        lorebookEntryExtractionHelper.processEntriesFound(entriesFound, messages, author.getJDA());
+
+        final Gpt3Request request = gptRequestTranslator.buildRequest(prompt, eventData.getPersona());
+        return openAiService.callGptApi(request, eventData).map(response -> {
             final String responseText = response.getChoices().get(0).getText();
             if (StringUtils.isBlank(responseText)) {
                 throw new ModelResponseBlankException();
@@ -41,6 +58,6 @@ public class Gpt3ModelService implements GptModelService {
 
             return responseText.trim();
         })
-        .doOnError(ModelResponseBlankException.class::isInstance, e -> commonErrorHandler.handleEmptyResponse(messageEventData));
+        .doOnError(ModelResponseBlankException.class::isInstance, e -> commonErrorHandler.handleEmptyResponse(eventData));
     }
 }

--- a/src/main/java/es/thalesalv/gptbot/application/service/commands/CreateLorebookEntryService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/commands/CreateLorebookEntryService.java
@@ -59,9 +59,9 @@ public class CreateLorebookEntryService implements CommandService {
                 event.replyModal(modal).queue();
                 return;
             }
-
-            event.reply("This command cannot be issued from this channel.").setEphemeral(true).complete();
         });
+
+        event.reply("This command cannot be issued from this channel.").setEphemeral(true).complete();
     }
 
     @Override

--- a/src/main/java/es/thalesalv/gptbot/application/service/commands/UpdateLorebookEntryService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/commands/UpdateLorebookEntryService.java
@@ -73,9 +73,9 @@ public class UpdateLorebookEntryService implements CommandService {
                     event.replyModal(modalEntry).queue();
                     return;
                 }
-
-                event.reply("This command cannot be issued from this channel.").setEphemeral(true).complete();
             });
+
+            event.reply("This command cannot be issued from this channel.").setEphemeral(true).complete();
         } catch (MissingRequiredSlashCommandOptionException e) {
             LOGGER.info("User tried to use update command without ID");
             event.reply(MISSING_ID_MESSAGE).setEphemeral(true).complete();

--- a/src/main/java/es/thalesalv/gptbot/application/service/commands/UpdateLorebookEntryService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/commands/UpdateLorebookEntryService.java
@@ -21,7 +21,6 @@ import es.thalesalv.gptbot.adapters.data.db.repository.LorebookRegexRepository;
 import es.thalesalv.gptbot.adapters.data.db.repository.LorebookRepository;
 import es.thalesalv.gptbot.application.config.BotConfig;
 import es.thalesalv.gptbot.application.config.CommandEventData;
-import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.application.service.ModerationService;
 import es.thalesalv.gptbot.application.translator.LorebookEntryToDTOTranslator;
 import es.thalesalv.gptbot.domain.exception.LorebookEntryNotFoundException;
@@ -63,10 +62,9 @@ public class UpdateLorebookEntryService implements CommandService {
             botConfig.getPersonas().forEach(persona -> {
                 final boolean isCurrentChannel = persona.getChannelIds().stream().anyMatch(id -> event.getChannel().getId().equals(id));
                 if (isCurrentChannel) {
-                    contextDatastore.setPersona(persona);
                     final UUID entryId = retrieveEntryId(event.getOption("lorebook-entry-id"));
                     contextDatastore.setCommandEventData(CommandEventData.builder()
-                            .lorebookEntryId(entryId).build());
+                            .lorebookEntryId(entryId).persona(persona).build());
 
                     final var entry = lorebookRegexRepository.findByLorebookEntry(LorebookEntry.builder().id(entryId).build())
                             .orElseThrow(LorebookEntryNotFoundException::new);
@@ -103,7 +101,6 @@ public class UpdateLorebookEntryService implements CommandService {
             final String playerId = retrieveDiscordPlayerId(event.getValue("lorebook-entry-player"),
                     event.getUser().getId());
 
-            final Persona persona = contextDatastore.getPersona();
             final LorebookRegex updatedEntry = updateEntry(updatedEntryDescription, entryId,
                     updatedEntryName, playerId, updatedEntryRegex);
 
@@ -111,7 +108,7 @@ public class UpdateLorebookEntryService implements CommandService {
             final String loreEntryJson = objectMapper.setSerializationInclusion(Include.NON_EMPTY)
                     .writerWithDefaultPrettyPrinter().writeValueAsString(entry);
 
-            moderationService.moderate(persona, loreEntryJson, event).subscribe(response -> {
+            moderationService.moderate(loreEntryJson, contextDatastore.getCommandEventData(), event).subscribe(response -> {
                 event.reply(MessageFormat.format(ENTRY_UPDATED,
                 updatedEntry.getLorebookEntry().getName(), loreEntryJson))
                         .setEphemeral(true).complete();
@@ -176,13 +173,13 @@ public class UpdateLorebookEntryService implements CommandService {
                 .orElse(lorebookRegex.getLorebookEntry().getName());
 
         final TextInput lorebookEntryRegex = TextInput
-                .create("lorebook-entry-regex", "Regular Expression (optional)", TextInputStyle.SHORT)
+                .create("lorebook-entry-regex", "Regular expression (optional)", TextInputStyle.SHORT)
                 .setValue(regex)
                 .setRequired(false)
                 .build();
 
         final TextInput lorebookEntryDescription = TextInput
-                .create("lorebook-entry-desc", "Lorebook Entry Name", TextInputStyle.PARAGRAPH)
+                .create("lorebook-entry-desc", "Description", TextInputStyle.PARAGRAPH)
                 .setValue(lorebookRegex.getLorebookEntry().getDescription())
                 .setMaxLength(150)
                 .setRequired(true)

--- a/src/main/java/es/thalesalv/gptbot/application/service/helper/MessageFormatHelper.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/helper/MessageFormatHelper.java
@@ -1,0 +1,147 @@
+package es.thalesalv.gptbot.application.service.helper;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import es.thalesalv.gptbot.adapters.data.db.entity.LorebookEntry;
+import es.thalesalv.gptbot.adapters.data.db.entity.LorebookRegex;
+import es.thalesalv.gptbot.adapters.data.db.repository.LorebookRegexRepository;
+import es.thalesalv.gptbot.adapters.data.db.repository.LorebookRepository;
+import es.thalesalv.gptbot.application.config.MessageEventData;
+import es.thalesalv.gptbot.domain.model.openai.gpt.ChatGptMessage;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Mentions;
+import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.entities.User;
+
+@Component
+@RequiredArgsConstructor
+public class MessageFormatHelper {
+
+    private static final String ROLE_SYSTEM = "system";
+    private static final String ROLE_ASSISTANT = "assistant";
+    private static final String ROLE_USER = "user";
+    private static final String DUNGEON_MASTER = "Dungeon Master";
+    private static final String CHARACTER_DESCRIPTION = "{0} description: {1}";
+    private static final String RPG_DM_INSTRUCTIONS = "I will remember to never act or speak on behalf of {0}. I will not repeat what {0} just said. I will only describe the world around {0}.";
+
+    private final LorebookRepository lorebookRepository;
+    private final LorebookRegexRepository lorebookRegexRepository;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageFormatHelper.class);
+
+    /**
+     * Extracts player characters entries from database given the player's Discord user ID
+     * @param entriesFound List of entries found in the messages until now
+     * @param messages List of messages in the channel
+     * @param player Player user
+     * @param mentions Mentioned users (their characters are extracted too)
+     */
+    public void handlePlayerCharacterEntries(final Set<LorebookEntry> entriesFound, final List<String> messages, final User player, final Mentions mentions) {
+
+        LOGGER.debug("Entered player character entry handling");
+        lorebookRepository.findByPlayerDiscordId(player.getId())
+                .ifPresent(entry -> {
+                    entriesFound.add(entry);
+                    messages.replaceAll(m -> m.replaceAll(player.getAsTag(), entry.getName())
+                            .replaceAll("(@|)" + player.getName(), entry.getName()));
+                });
+
+        mentions.getUsers().stream()
+                .forEach(mention -> lorebookRepository.findByPlayerDiscordId(mention.getId())
+                        .ifPresent(entry -> {
+                            entriesFound.add(entry);
+                            messages.replaceAll(m -> m.replaceAll(mention.getAsTag(), entry.getName())
+                                    .replaceAll("(@|)" + mention.getName(), entry.getName()));
+                        }));
+    }
+
+    /**
+     * Extracts lore entries from the conversation when they're mentioned by name
+     * @param messages List of messages in the channel
+     * @param entriesFound List of entries found in the messages until now
+     */
+    public void handleEntriesMentioned(final List<String> messageList, final Set<LorebookEntry> entriesFound) {
+
+        LOGGER.debug("Entered mentioned entries handling");
+        final String messages = messageList.stream().collect(Collectors.joining("\n"));
+        List<LorebookRegex> charRegex = lorebookRegexRepository.findAll();
+        charRegex.forEach(e -> {
+            Pattern p = Pattern.compile(e.getRegex());
+            Matcher matcher = p.matcher(messages);
+            if (matcher.find()) {
+                lorebookRepository.findById(e.getLorebookEntry().getId()).ifPresent(entriesFound::add);
+            }
+        });
+    }
+
+    public void processEntriesFound(final Set<LorebookEntry> entriesFound, final List<String> messages, final JDA jda) {
+
+        entriesFound.stream().forEach(entry -> {
+            if (StringUtils.isNotBlank(entry.getPlayerDiscordId())) {
+                messages.add(0, MessageFormat.format(RPG_DM_INSTRUCTIONS, entry.getName()));
+            }
+
+            messages.add(0, MessageFormat.format(CHARACTER_DESCRIPTION, entry.getName(), entry.getDescription()));
+            Optional.ofNullable(entry.getPlayerDiscordId()).ifPresent(id -> {
+                final User p = jda.retrieveUserById(id).complete();
+                messages.replaceAll(m -> m.replaceAll(p.getAsTag(), entry.getName())
+                        .replaceAll("(@|)" + p.getName(), entry.getName()));
+            });
+        });
+    }
+
+    public List<ChatGptMessage> formatMessagesForChatGpt(final Set<LorebookEntry> entriesFound, final List<String> messages, final MessageEventData eventData) {
+
+        final SelfUser bot = eventData.getBot();
+        final String personality = eventData.getPersona().getPersonality().replace("{0}", bot.getName());
+        final List<ChatGptMessage> chatGptMessages = messages.stream()
+                .filter(msg -> !msg.trim().equals((bot.getName() + " said:").trim()))
+                .map(msg -> {
+                    String role = determineRole(msg, bot);
+                    msg = formatBotName(msg, bot);
+                    return ChatGptMessage.builder()
+                            .role(role)
+                            .content(msg)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        chatGptMessages.add(0, ChatGptMessage.builder()
+                .role(ROLE_SYSTEM)
+                .content(MessageFormat.format(personality, bot.getName())
+                        .replace("@" + bot.getName(), StringUtils.EMPTY).trim())
+                .build());
+            
+        return chatGptMessages;
+    }
+
+    private String formatBotName(String msg, SelfUser bot) {
+
+        return msg.replace(bot.getName() + " said: ", StringUtils.EMPTY)
+                .replaceAll("Dungeon Master says: ", StringUtils.EMPTY);
+    }
+
+    private String determineRole(String message, SelfUser bot) {
+
+        final boolean isChat = message.matches("^(.*) (says|said|quoted|replied).*((.|\n)*)");
+        if (message.startsWith(bot.getName()) || message.startsWith(DUNGEON_MASTER)) {
+            return ROLE_ASSISTANT;
+        } else if (isChat && !message.startsWith("I will remember to never")) {
+            return ROLE_USER;
+        }
+
+        return ROLE_SYSTEM;
+    }
+}

--- a/src/main/java/es/thalesalv/gptbot/application/service/helper/MessageFormatHelper.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/helper/MessageFormatHelper.java
@@ -86,7 +86,7 @@ public class MessageFormatHelper {
         });
     }
 
-    public void processEntriesFound(final Set<LorebookEntry> entriesFound, final List<String> messages, final JDA jda) {
+    public void processEntriesFoundForRpg(final Set<LorebookEntry> entriesFound, final List<String> messages, final JDA jda) {
 
         entriesFound.stream().forEach(entry -> {
             if (StringUtils.isNotBlank(entry.getPlayerDiscordId())) {
@@ -99,6 +99,13 @@ public class MessageFormatHelper {
                 messages.replaceAll(m -> m.replaceAll(p.getAsTag(), entry.getName())
                         .replaceAll("(@|)" + p.getName(), entry.getName()));
             });
+        });
+    }
+
+    public void processEntriesFoundForChat(final Set<LorebookEntry> entriesFound, final List<String> messages, final JDA jda) {
+
+        entriesFound.stream().forEach(entry -> {
+            messages.add(0, MessageFormat.format(CHARACTER_DESCRIPTION, entry.getName(), entry.getDescription()));
         });
     }
 

--- a/src/main/java/es/thalesalv/gptbot/application/service/interfaces/GptModelService.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/interfaces/GptModelService.java
@@ -3,11 +3,10 @@ package es.thalesalv.gptbot.application.service.interfaces;
 import java.util.List;
 
 import es.thalesalv.gptbot.application.config.MessageEventData;
-import es.thalesalv.gptbot.application.config.Persona;
 import reactor.core.publisher.Mono;
 
 @FunctionalInterface
 public interface GptModelService {
 
-    Mono<String> generate(final MessageEventData messageEventData, final String prompt, final Persona persona, final List<String> messages);
+    Mono<String> generate(final String prompt, final List<String> messages, final MessageEventData messageEventData);
 }

--- a/src/main/java/es/thalesalv/gptbot/application/service/usecases/BotUseCase.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/usecases/BotUseCase.java
@@ -1,7 +1,6 @@
 package es.thalesalv.gptbot.application.service.usecases;
 
 import es.thalesalv.gptbot.application.config.MessageEventData;
-import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.application.service.interfaces.GptModelService;
 import net.dv8tion.jda.api.entities.Mentions;
 
@@ -10,10 +9,9 @@ public interface BotUseCase {
 
     /**
      * Formats the prompt so it can be sent to the AI based on specific logic
-     * @param persona Object containing the current persona with bot behavior
      * @param messageEventData Object containing data on the message event
      * @param mentions List of Discord users mentioned in the conversation
      * @param model Model to be used for generation
      */
-    void generateResponse(final Persona persona, final MessageEventData messageEventData, final Mentions mentions, final GptModelService model);
+    void generateResponse(final MessageEventData messageEventData, final Mentions mentions, final GptModelService model);
 }

--- a/src/main/java/es/thalesalv/gptbot/application/service/usecases/ChatbotUseCase.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/usecases/ChatbotUseCase.java
@@ -31,10 +31,11 @@ public class ChatbotUseCase implements BotUseCase {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChatbotUseCase.class);
 
     @Override
-    public void generateResponse(final Persona persona, final MessageEventData messageEventData, final Mentions mentions, final GptModelService model) {
+    public void generateResponse(final MessageEventData messageEventData, final Mentions mentions, final GptModelService model) {
 
         LOGGER.debug("Entered generation for normal text.");
         messageEventData.getChannel().sendTyping().complete();
+        final Persona persona = messageEventData.getPersona();
         final List<String> messages = new ArrayList<>();
         final Message replyMessage = messageEventData.getMessage().getReferencedMessage();
 
@@ -46,8 +47,8 @@ public class ChatbotUseCase implements BotUseCase {
         }
 
         final String chatifiedMessage = chatifyMessages(messageEventData.getBot(), messages);
-        moderationService.moderate(messageEventData, persona, chatifiedMessage)
-                .subscribe(moderationResult -> model.generate(messageEventData, chatifiedMessage, persona, messages)
+        moderationService.moderate(chatifiedMessage, messageEventData)
+                .subscribe(moderationResult -> model.generate(chatifiedMessage, messages, messageEventData)
                 .subscribe(textResponse -> messageEventData.getChannel().sendMessage(textResponse).queue()));
     }
 

--- a/src/main/java/es/thalesalv/gptbot/application/service/usecases/DungeonMasterUseCase.java
+++ b/src/main/java/es/thalesalv/gptbot/application/service/usecases/DungeonMasterUseCase.java
@@ -3,12 +3,7 @@ package es.thalesalv.gptbot.application.service.usecases;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -16,64 +11,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import es.thalesalv.gptbot.adapters.data.db.entity.LorebookEntry;
-import es.thalesalv.gptbot.adapters.data.db.entity.LorebookRegex;
-import es.thalesalv.gptbot.adapters.data.db.repository.LorebookRegexRepository;
-import es.thalesalv.gptbot.adapters.data.db.repository.LorebookRepository;
 import es.thalesalv.gptbot.application.config.MessageEventData;
 import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.application.service.ModerationService;
 import es.thalesalv.gptbot.application.service.interfaces.GptModelService;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Mentions;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.SelfUser;
-import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 
 @Component
 @RequiredArgsConstructor
 public class DungeonMasterUseCase implements BotUseCase {
 
-    private final JDA jda;
     private final ModerationService moderationService;
-    private final LorebookRepository lorebookRepository;
-    private final LorebookRegexRepository lorebookRegexRepository;
 
-    private static final String RPG_DM_INSTRUCTIONS = "I will remember to never act or speak on behalf of {0}. I will not repeat what {0} just said. I will only describe the world around {0}.";
-    private static final String CHARACTER_DESCRIPTION = "{0} description: {1}";
     private static final Logger LOGGER = LoggerFactory.getLogger(DungeonMasterUseCase.class);
 
     @Override
-    public void generateResponse(final Persona persona, final MessageEventData messageEventData, final Mentions mentions, final GptModelService model) {
+    public void generateResponse(final MessageEventData messageEventData, final Mentions mentions, final GptModelService model) {
 
         LOGGER.debug("Entered generation of response for RPG");
         if (mentions.isMentioned(messageEventData.getBot(), Message.MentionType.USER)) {
             messageEventData.getChannel().sendTyping().complete();
+            final Persona persona = messageEventData.getPersona();
             final List<String> messages = new ArrayList<>();
-            final Set<LorebookEntry> entriesFound = new HashSet<>();
 
             handleMessageHistory(persona, messages, messageEventData.getBot(), messageEventData.getChannel());
-            handlePlayerCharacterEntries(entriesFound, messages, messageEventData.getMessageAuthor(), mentions);
-            handleEntriesMentioned(messages, entriesFound);
-
-            entriesFound.stream().forEach(entry -> {
-                if (StringUtils.isNotBlank(entry.getPlayerDiscordId())) {
-                    messages.add(0, MessageFormat.format(RPG_DM_INSTRUCTIONS, entry.getName()));
-                }
-
-                messages.add(0, MessageFormat.format(CHARACTER_DESCRIPTION, entry.getName(), entry.getDescription()));
-                Optional.ofNullable(entry.getPlayerDiscordId()).ifPresent(id -> {
-                    final User p = jda.retrieveUserById(id).complete();
-                    messages.replaceAll(m -> m.replaceAll(p.getAsTag(), entry.getName())
-                            .replaceAll("(@|)" + p.getName(), entry.getName()));
-                });
-            });
 
             final String chatifiedMessage = formatAdventureForPrompt(messages, messageEventData.getBot());
-            moderationService.moderate(messageEventData, persona, chatifiedMessage)
-                    .subscribe(moderationResult -> model.generate(messageEventData, chatifiedMessage, persona, messages)
+            moderationService.moderate(chatifiedMessage, messageEventData)
+                    .subscribe(moderationResult -> model.generate(chatifiedMessage, messages, messageEventData)
                     .subscribe(textResponse -> messageEventData.getChannel().sendMessage(textResponse).queue()));
         }
     }
@@ -85,7 +54,7 @@ public class DungeonMasterUseCase implements BotUseCase {
      * @param bot Bot user
      * @param channel Channel where the conversation is happening
      */
-    private void handleMessageHistory(final Persona persona, List<String> messages, SelfUser bot, MessageChannelUnion channel) {
+    private void handleMessageHistory(final Persona persona, final List<String> messages, final SelfUser bot, final MessageChannelUnion channel) {
     
         LOGGER.debug("Entered history handling for RPG");
         channel.getHistory()
@@ -105,52 +74,7 @@ public class DungeonMasterUseCase implements BotUseCase {
         Collections.reverse(messages);
     }
 
-    /**
-     * Extracts player characters entries from database given the player's Discord user ID
-     * @param entriesFound List of entries found in the messages until now
-     * @param messages List of messages in the channel
-     * @param player Player user
-     * @param mentions Mentioned users (their characters are extracted too)
-     */
-    private void handlePlayerCharacterEntries(Set<LorebookEntry> entriesFound, List<String> messages, User player, Mentions mentions) {
-
-        LOGGER.debug("Entered player character entry handling");
-        lorebookRepository.findByPlayerDiscordId(player.getId())
-                .ifPresent(entry -> {
-                    entriesFound.add(entry);
-                    messages.replaceAll(m -> m.replaceAll(player.getAsTag(), entry.getName())
-                            .replaceAll("(@|)" + player.getName(), entry.getName()));
-                });
-
-        mentions.getUsers().stream()
-                .forEach(mention -> lorebookRepository.findByPlayerDiscordId(mention.getId())
-                        .ifPresent(entry -> {
-                            entriesFound.add(entry);
-                            messages.replaceAll(m -> m.replaceAll(mention.getAsTag(), entry.getName())
-                                    .replaceAll("(@|)" + mention.getName(), entry.getName()));
-                        }));
-    }
-
-    /**
-     * Extracts lore entries from the conversation when they're mentioned by name
-     * @param messages List of messages in the channel
-     * @param entriesFound List of entries found in the messages until now
-     */
-    private void handleEntriesMentioned(List<String> messageList, Set<LorebookEntry> entriesFound) {
-
-        LOGGER.debug("Entered mentioned entries handling");
-        final String messages = messageList.stream().collect(Collectors.joining("\n"));
-        List<LorebookRegex> charRegex = lorebookRegexRepository.findAll();
-        charRegex.forEach(e -> {
-            Pattern p = Pattern.compile(e.getRegex());
-            Matcher matcher = p.matcher(messages);
-            if (matcher.find()) {
-                lorebookRepository.findById(e.getLorebookEntry().getId()).ifPresent(entriesFound::add);
-            }
-        });
-    }
-
-    private String formatAdventureForPrompt(List<String> messages, SelfUser bot) {
+    private String formatAdventureForPrompt(final List<String> messages, final SelfUser bot) {
 
         LOGGER.debug("Entered RPG conversation formatter");
         messages.add("Dungeon Master says:");

--- a/src/main/java/es/thalesalv/gptbot/application/translator/ChatGptRequestTranslator.java
+++ b/src/main/java/es/thalesalv/gptbot/application/translator/ChatGptRequestTranslator.java
@@ -1,87 +1,27 @@
 package es.thalesalv.gptbot.application.translator;
 
-import java.text.MessageFormat;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.domain.model.openai.gpt.ChatGptMessage;
 import es.thalesalv.gptbot.domain.model.openai.gpt.ChatGptRequest;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.SelfUser;
 
 @Component
 @RequiredArgsConstructor
 public class ChatGptRequestTranslator {
 
-    @Value("${config.bot.generation.default-max-tokens}")
-    private int defaultMaxTokens;
-
-    @Value("${config.bot.generation.default-temperature}")
-    private double defaultTemperature;
-
-    @Value("${config.bot.generation.default-presence-penalty}")
-    private double defaultPresencePenalty;
-
-    @Value("${config.bot.generation.default-frequency-penalty}")
-    private double defaultFrequencyPenalty;
-
-    private static final String ROLE_SYSTEM = "system";
-    private static final String ROLE_ASSISTANT = "assistant";
-    private static final String ROLE_USER = "user";
-    private static final String DUNGEON_MASTER = "Dungeon Master";
-
-    private final JDA jda;
-
-    public ChatGptRequest buildRequest(List<String> messages, String model, Persona persona) {
-
-        final SelfUser bot = jda.getSelfUser();
-        final String personality = persona.getPersonality().replace("{0}", bot.getName());
-        final int maxTokens = persona == null ? defaultMaxTokens : persona.getMaxTokens();
-        final double temperature = persona == null ? defaultTemperature : persona.getTemperature();
-        final double presencePenalty = persona == null ? defaultPresencePenalty : persona.getPresencePenalty();
-        final double frequencyPenalty = persona == null ? defaultFrequencyPenalty : persona.getFrequencyPenalty();
-
-        List<ChatGptMessage> chatGptMessages = messages.stream()
-                .filter(msg -> !msg.trim().equals((bot.getName() + " said:").trim()))
-                .map(msg -> {
-                    String role = determineRole(msg, bot);
-                    msg = msg.replace(bot.getName() + " said: ", StringUtils.EMPTY)
-                    .replaceAll("Dungeon Master says: ", StringUtils.EMPTY);
-                    return ChatGptMessage.builder()
-                            .role(role)
-                            .content(msg)
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        chatGptMessages.add(0, ChatGptMessage.builder()
-                .role(ROLE_SYSTEM)
-                .content(MessageFormat.format(personality, bot.getName())
-                        .replace("@" + bot.getName(), StringUtils.EMPTY).trim())
-                .build());
+    public ChatGptRequest buildRequest(final List<String> messages, final Persona persona, final List<ChatGptMessage> chatGptMessages) {
 
         return ChatGptRequest.builder()
             .messages(chatGptMessages)
-            .model(model)
-            .maxTokens(maxTokens)
-            .temperature(temperature)
-            .presencePenalty(presencePenalty)
-            .frequencyPenalty(frequencyPenalty)
+            .model(persona.getModelName())
+            .maxTokens(persona.getMaxTokens())
+            .temperature(persona.getTemperature())
+            .presencePenalty(persona.getPresencePenalty())
+            .frequencyPenalty(persona.getFrequencyPenalty())
             .build();
-    }
-
-    private String determineRole(String message, SelfUser bot) {
-        
-        if (message.startsWith(bot.getName()) || message.startsWith(DUNGEON_MASTER)) {
-            return ROLE_ASSISTANT;
-        } else {
-            return ROLE_USER;
-        }
     }
 }

--- a/src/main/java/es/thalesalv/gptbot/application/translator/Gpt3RequestTranslator.java
+++ b/src/main/java/es/thalesalv/gptbot/application/translator/Gpt3RequestTranslator.java
@@ -1,6 +1,5 @@
 package es.thalesalv.gptbot.application.translator;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import es.thalesalv.gptbot.application.config.Persona;
@@ -9,33 +8,17 @@ import es.thalesalv.gptbot.domain.model.openai.gpt.Gpt3Request;
 @Component
 public class Gpt3RequestTranslator {
 
-    @Value("${config.bot.generation.default-max-tokens}")
-    private int defaultMaxTokens;
-
-    @Value("${config.bot.generation.default-temperature}")
-    private double defaultTemperature;
-
-    @Value("${config.bot.generation.default-presence-penalty}")
-    private double defaultPresencePenalty;
-
-    @Value("${config.bot.generation.default-frequency-penalty}")
-    private double defaultFrequencyPenalty;
-
-    public Gpt3Request buildRequest(final String prompt, final String model, final Persona persona) {
+    public Gpt3Request buildRequest(final String prompt, final Persona persona) {
 
         final String formattedPrompt = persona.getPersonality() + "\n" + prompt;
-        final int maxTokens = persona == null ? defaultMaxTokens : persona.getMaxTokens();
-        final double temperature = persona == null ? defaultTemperature : persona.getTemperature();
-        final double presencePenalty = persona == null ? defaultPresencePenalty : persona.getPresencePenalty();
-        final double frequencyPenalty = persona == null ? defaultFrequencyPenalty : persona.getFrequencyPenalty();
 
         return Gpt3Request.builder()
             .prompt(formattedPrompt)
-            .model(model)
-            .maxTokens(maxTokens)
-            .temperature(temperature)
-            .presencePenalty(presencePenalty)
-            .frequencyPenalty(frequencyPenalty)
+            .model(persona.getModelName())
+            .maxTokens(persona.getMaxTokens())
+            .temperature(persona.getTemperature())
+            .presencePenalty(persona.getPresencePenalty())
+            .frequencyPenalty(persona.getFrequencyPenalty())
             .build();
     }
 }

--- a/src/main/java/es/thalesalv/gptbot/application/translator/MessageEventDataTranslator.java
+++ b/src/main/java/es/thalesalv/gptbot/application/translator/MessageEventDataTranslator.java
@@ -3,6 +3,7 @@ package es.thalesalv.gptbot.application.translator;
 import org.springframework.stereotype.Component;
 
 import es.thalesalv.gptbot.application.config.MessageEventData;
+import es.thalesalv.gptbot.application.config.Persona;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
@@ -10,7 +11,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 @RequiredArgsConstructor
 public class MessageEventDataTranslator {
 
-    public MessageEventData translate(final MessageReceivedEvent event) {
+    public MessageEventData translate(final MessageReceivedEvent event, final Persona persona) {
 
         return MessageEventData.builder()
                 .bot(event.getJDA().getSelfUser())
@@ -18,6 +19,7 @@ public class MessageEventDataTranslator {
                 .message(event.getMessage())
                 .channel(event.getChannel())
                 .guild(event.getGuild())
+                .persona(persona)
                 .build();
     }
 }

--- a/src/test/java/es/thalesalv/gptbot/application/service/Gpt3ModelServiceTest.java
+++ b/src/test/java/es/thalesalv/gptbot/application/service/Gpt3ModelServiceTest.java
@@ -1,9 +1,10 @@
 package es.thalesalv.gptbot.application.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
 import java.util.ArrayList;
 
-import es.thalesalv.gptbot.application.config.MessageEventData;
-import net.dv8tion.jda.api.entities.Message;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,22 +15,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import es.thalesalv.gptbot.adapters.data.ContextDatastore;
 import es.thalesalv.gptbot.adapters.rest.OpenAIApiService;
+import es.thalesalv.gptbot.application.config.MessageEventData;
 import es.thalesalv.gptbot.application.config.Persona;
 import es.thalesalv.gptbot.application.errorhandling.CommonErrorHandler;
+import es.thalesalv.gptbot.application.service.helper.MessageFormatHelper;
 import es.thalesalv.gptbot.application.translator.Gpt3RequestTranslator;
 import es.thalesalv.gptbot.domain.exception.ModelResponseBlankException;
 import es.thalesalv.gptbot.domain.model.openai.gpt.Gpt3Request;
 import es.thalesalv.gptbot.testutils.OpenAiApiBuilder;
 import es.thalesalv.gptbot.testutils.PersonaBuilder;
+import net.dv8tion.jda.api.entities.Message;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 
 @SuppressWarnings("all")
 @ExtendWith(MockitoExtension.class)
 public class Gpt3ModelServiceTest {
+
+    @Mock
+    private MessageFormatHelper messageFormatHelper;
 
     @Mock
     private ContextDatastore contextDatastore;
@@ -54,13 +58,15 @@ public class Gpt3ModelServiceTest {
         final Persona persona = PersonaBuilder.persona();
         final Message message = Mockito.mock(Message.class);
         final MessageEventData eventData = PersonaBuilder.messageEventData();
-        Mockito.when(gpt3RequestTranslator.buildRequest(anyString(), anyString(), any(Persona.class)))
+        eventData.setPersona(persona);
+
+        Mockito.when(gpt3RequestTranslator.buildRequest(anyString(), any(Persona.class)))
                 .thenReturn(request);
 
         Mockito.when(openAiService.callGptApi(request, eventData))
                 .thenReturn(Mono.just(OpenAiApiBuilder.buildGptResponse()));
 
-        StepVerifier.create(gpt3ModelService.generate(eventData, prompt, persona, new ArrayList<String>()))
+        StepVerifier.create(gpt3ModelService.generate(prompt, new ArrayList<String>(), eventData))
                 .assertNext(resp -> {
                     Assertions.assertEquals("AI response text", resp);
                 }).verifyComplete();
@@ -74,14 +80,15 @@ public class Gpt3ModelServiceTest {
         final Persona persona = PersonaBuilder.persona();
         final Message message = Mockito.mock(Message.class);
         final MessageEventData eventData = PersonaBuilder.messageEventData();
+        eventData.setPersona(persona);
 
-        Mockito.when(gpt3RequestTranslator.buildRequest(prompt, "text-davinci-003", persona))
+        Mockito.when(gpt3RequestTranslator.buildRequest(prompt, persona))
                 .thenReturn(request);
 
         Mockito.when(openAiService.callGptApi(request, eventData))
                 .thenReturn(Mono.just(OpenAiApiBuilder.buildGptResponseEmptyText()));
 
-        StepVerifier.create(gpt3ModelService.generate(eventData, prompt, persona, new ArrayList<String>()))
+        StepVerifier.create(gpt3ModelService.generate(prompt, new ArrayList<String>(), eventData))
                 .verifyError(ModelResponseBlankException.class);
     }
 }

--- a/src/test/java/es/thalesalv/gptbot/application/service/ModerationServiceTest.java
+++ b/src/test/java/es/thalesalv/gptbot/application/service/ModerationServiceTest.java
@@ -57,9 +57,9 @@ public class ModerationServiceTest {
         final MessageEventData eventData = PersonaBuilder.messageEventData();
 
         Mockito.when(openAIApiService.callModerationApi(any(ModerationRequest.class))).thenReturn(Mono.just(ModerationBuilder.moderationResponse()));
-        Mockito.when(moderationService.moderate(eventData, persona, prompt)).thenReturn(Mono.just(ModerationBuilder.moderationResponse()));
+        Mockito.when(moderationService.moderate(prompt, eventData)).thenReturn(Mono.just(ModerationBuilder.moderationResponse()));
 
-        StepVerifier.create(moderationService.moderate(eventData, persona, prompt))
+        StepVerifier.create(moderationService.moderate(prompt, eventData))
                 .assertNext(r -> {
                     Assertions.assertEquals("text-davinci-003", r.getModel());
                     r.getModerationResult().get(0).getCategoryScores()
@@ -90,9 +90,9 @@ public class ModerationServiceTest {
         Mockito.when(user.openPrivateChannel().complete().sendMessage(anyString())).thenReturn(Mockito.mock(MessageCreateAction.class));
         Mockito.when(user.openPrivateChannel().complete().sendMessage(anyString()).complete()).thenReturn(Mockito.mock(Message.class));
         Mockito.when(openAIApiService.callModerationApi(any(ModerationRequest.class))).thenReturn(response);
-        Mockito.when(moderationService.moderate(eventData, persona, prompt)).thenReturn(response);
+        Mockito.when(moderationService.moderate(prompt, eventData)).thenReturn(response);
 
-        StepVerifier.create(moderationService.moderate(eventData, persona, prompt))
+        StepVerifier.create(moderationService.moderate(prompt, eventData))
                 .verifyError(ModerationException.class);
     }
 
@@ -117,9 +117,9 @@ public class ModerationServiceTest {
         Mockito.when(user.openPrivateChannel().complete().sendMessage(anyString())).thenReturn(Mockito.mock(MessageCreateAction.class));
         Mockito.when(user.openPrivateChannel().complete().sendMessage(anyString()).complete()).thenReturn(Mockito.mock(Message.class));
         Mockito.when(openAIApiService.callModerationApi(any())).thenReturn(response);
-        Mockito.when(moderationService.moderate(eventData, persona, prompt)).thenReturn(response);
+        Mockito.when(moderationService.moderate(prompt, eventData)).thenReturn(response);
 
-        StepVerifier.create(moderationService.moderate(eventData, persona, prompt))
+        StepVerifier.create(moderationService.moderate(prompt, eventData))
                 .verifyError(ModerationException.class);
     }
 }

--- a/src/test/java/es/thalesalv/gptbot/testutils/DiscordMocker.java
+++ b/src/test/java/es/thalesalv/gptbot/testutils/DiscordMocker.java
@@ -3,6 +3,8 @@ package es.thalesalv.gptbot.testutils;
 import java.util.EnumSet;
 import java.util.List;
 
+import org.mockito.Mockito;
+
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.SelfUser;
@@ -92,7 +94,7 @@ public class DiscordMocker {
 
             @Override
             public JDA getJDA() {
-                throw new UnsupportedOperationException("Unimplemented method 'getJDA'");
+                return Mockito.mock(JDA.class);
             }
 
             @Override

--- a/src/test/java/es/thalesalv/gptbot/testutils/PersonaBuilder.java
+++ b/src/test/java/es/thalesalv/gptbot/testutils/PersonaBuilder.java
@@ -56,11 +56,13 @@ public class PersonaBuilder {
     }
 
     public static MessageEventData messageEventData() {
+
         return MessageEventData.builder()
                 .bot(DiscordMocker.buildSelfUser())
                 .channel(DiscordMocker.buildChannel())
                 .messageAuthor(DiscordMocker.buildUser())
                 .message(MessageBuilder.getMessage())
+                .persona(persona())
                 .build();
     }
 }


### PR DESCRIPTION
- Changed request formatting mechanic to properly format the requests of different models
- Properly formatted roles of ChatGPT required format
- Separated the way entries are inserted for RPG or chatbot
- Fixed bug with commands that would not work in some channels
- Fixed entry "description" label that was being called "name"