### PR TITLE
REFACTOR: Improved JDA event handling

### DIFF
--- a/src/main/java/es/thalesalv/gptbot/adapters/beans/JDAConfigurationBean.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/beans/JDAConfigurationBean.java
@@ -1,12 +1,10 @@
 package es.thalesalv.gptbot.adapters.beans;
 
+import es.thalesalv.gptbot.adapters.discord.EventDispatcher;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import es.thalesalv.gptbot.adapters.discord.listener.GenericEventListener;
-import es.thalesalv.gptbot.adapters.discord.listener.MessageListener;
-import es.thalesalv.gptbot.adapters.discord.listener.SlashCommandListener;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -19,16 +17,13 @@ public class JDAConfigurationBean {
     @Value("${config.discord.api-token}")
     private String discordApiToken;
 
-    private final SlashCommandListener slashCommandListener;
-    private final GenericEventListener discordBotEventListener;
-    private final MessageListener discordBotMessageListener;
+    private final EventDispatcher dispatcherListenerAdapter;
 
     @Bean
     public JDA jda() {
 
         final Object[] eventListeners = {
-            discordBotEventListener, discordBotMessageListener,
-            slashCommandListener
+                dispatcherListenerAdapter
         };
 
         return JDABuilder.createDefault(discordApiToken)

--- a/src/main/java/es/thalesalv/gptbot/adapters/discord/EventDispatcher.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/discord/EventDispatcher.java
@@ -1,0 +1,50 @@
+package es.thalesalv.gptbot.adapters.discord;
+
+import es.thalesalv.gptbot.adapters.discord.listener.InteractionListener;
+import es.thalesalv.gptbot.adapters.discord.listener.MessageListener;
+import es.thalesalv.gptbot.adapters.discord.listener.SessionListener;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.events.session.ReadyEvent;
+import net.dv8tion.jda.api.events.session.SessionDisconnectEvent;
+import net.dv8tion.jda.api.events.session.ShutdownEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.stereotype.Component;
+
+
+@RequiredArgsConstructor
+@Component
+public class EventDispatcher extends ListenerAdapter {
+    private final SessionListener sessionListener;
+    private final InteractionListener interactionListener;
+    private final MessageListener messageListener;
+
+
+    @Override
+    public void onReady(ReadyEvent event) {
+        sessionListener.onReady(event);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        interactionListener.onSlashCommand(event);
+    }
+
+    @Override
+    public void onModalInteraction(ModalInteractionEvent event) {
+        interactionListener.onModalInteraction(event);
+    }
+
+    @Override
+    public void onMessageReceived(MessageReceivedEvent event) {
+        messageListener.onMessageReceived(event);
+    }
+
+    @Override
+    public void onSessionDisconnect(SessionDisconnectEvent event) { sessionListener.onSessionDisconnect(event); }
+
+    @Override
+    public void onShutdown(ShutdownEvent event) { sessionListener.onShutdown(event); }
+}

--- a/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/InteractionListener.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/InteractionListener.java
@@ -1,5 +1,8 @@
 package es.thalesalv.gptbot.adapters.discord.listener;
 
+import jakarta.annotation.Nonnull;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -7,31 +10,29 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.stereotype.Service;
 
 import es.thalesalv.gptbot.application.service.commands.CommandService;
-import jakarta.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class SlashCommandListener extends ListenerAdapter {
+public class InteractionListener {
 
     private final BeanFactory beanFactory;
 
     private static final String NON_EXISTING_COMMAND = "The command you tried to use does not exist. Please use `create`, `retrieved`, `delete` or `update` as the argument.";
     private static final String LOREBOOK_ENTRY_SERVICE = "LorebookEntryService";
-    private static final Logger LOGGER = LoggerFactory.getLogger(SlashCommandListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InteractionListener.class);
 
-    @Override
-    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandInteractionEvent event) {
 
         try {
             LOGGER.debug("Received slash command event -> {}", event);
             event.deferReply();
             final String eventName = event.getName();
             if (eventName.equals("lorebook")) {
-                final String command = event.getOption("action").getAsString();
+                final String command = Optional.ofNullable(event.getOption("action")).map(OptionMapping::getAsString).orElseThrow(() -> new IllegalArgumentException("Did not receive slash command action"));
                 final CommandService commandService = (CommandService) beanFactory.getBean(command + LOREBOOK_ENTRY_SERVICE);
                 commandService.handle(event);
             }
@@ -41,7 +42,6 @@ public class SlashCommandListener extends ListenerAdapter {
         }
     }
 
-    @Override
     public void onModalInteraction(@Nonnull ModalInteractionEvent event) {
 
         LOGGER.debug("Received modal interaction event -> {}", event);

--- a/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/MessageListener.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/MessageListener.java
@@ -12,11 +12,10 @@ import es.thalesalv.gptbot.application.service.usecases.BotUseCase;
 import es.thalesalv.gptbot.application.translator.MessageEventDataTranslator;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 @Service
 @RequiredArgsConstructor
-public class MessageListener extends ListenerAdapter {
+public class MessageListener {
 
     private final BotConfig botConfig;
     private final ApplicationContext applicationContext;
@@ -26,7 +25,6 @@ public class MessageListener extends ListenerAdapter {
     private static final String USE_CASE = "UseCase";
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageListener.class);
 
-    @Override
     public void onMessageReceived(MessageReceivedEvent event) {
 
         LOGGER.debug("Message received -> {}", event);

--- a/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/SessionListener.java
+++ b/src/main/java/es/thalesalv/gptbot/adapters/discord/listener/SessionListener.java
@@ -1,32 +1,28 @@
 package es.thalesalv.gptbot.adapters.discord.listener;
 
+import net.dv8tion.jda.api.events.session.SessionDisconnectEvent;
+import net.dv8tion.jda.api.events.session.ShutdownEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.SelfUser;
-import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
-import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 
 @Service
-public class GenericEventListener implements EventListener {
+public class SessionListener {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GenericEventListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionListener.class);
 
-    @Override
-    public void onEvent(GenericEvent event) {
-
+    public void onReady(ReadyEvent event) {
         try {
             final SelfUser bot = event.getJDA().getSelfUser();
-            if (event instanceof ReadyEvent) {
                 LOGGER.info("{} is ready to chat!", bot.getName());
                 registerSlashCommands(event);
-            }
         } catch (IllegalStateException e) {
             if (e.getMessage().contains("Session is not yet ready!")) {
                 LOGGER.warn("Waiting for Discord session...");
@@ -36,7 +32,25 @@ public class GenericEventListener implements EventListener {
         }
     }
 
-    private void registerSlashCommands(GenericEvent event) {
+    public void onSessionDisconnect(SessionDisconnectEvent event) {
+        try {
+            final SelfUser bot = event.getJDA().getSelfUser();
+            LOGGER.info("{} is disconnected.", bot.getName());
+        } catch (Throwable t) {
+            LOGGER.error("Error during disconnect: ", t);
+        }
+    }
+
+    public void onShutdown(ShutdownEvent event) {
+        try {
+            final SelfUser bot = event.getJDA().getSelfUser();
+            LOGGER.info("{} is shutdown.", bot.getName());
+        } catch (Throwable t) {
+            LOGGER.error("Error during shutdown: ", t);
+        }
+    }
+
+    private void registerSlashCommands(ReadyEvent event) {
 
         LOGGER.debug("Registering slash commands.");
         final JDA jda = event.getJDA();


### PR DESCRIPTION
I created a single EventDispatcher which routes events to appropriate listeners segregated by JDA category. The is largely cosmetic as no functionality has been changed, however this is in anticipation of future functionality updates.