### PR TITLE
REFACTOR: Unnecessary code in MessageListener

### DIFF
--- a/src/main/java/es/thalesalv/chatrpg/adapters/discord/listener/MessageListener.java
+++ b/src/main/java/es/thalesalv/chatrpg/adapters/discord/listener/MessageListener.java
@@ -32,9 +32,8 @@ public class MessageListener {
     public void onMessageReceived(MessageReceivedEvent event) {
 
         if (!event.getAuthor().isBot()) {
-            channelRepository.findByChannelId(event.getChannel().getId()).stream()
-                    .findFirst()
-                    .map(channelEntityMapper::apply)
+            channelRepository.findByChannelId(event.getChannel().getId())
+                    .map(channelEntityMapper)
                     .ifPresent(channel -> {
                         LOGGER.debug("Received message by {} in {}: {}", event.getAuthor(), event.getChannel().getName(), event.getMessage().getContentDisplay());
                         final Persona persona = channel.getChannelConfig().getPersona();


### PR DESCRIPTION
Optional.stream().findFirst() is just... the original Optional Also because ChannelEntityToDTO implements Function<ChannelEntity,
  Channel>, it is not necessary to use channelMapper::apply, you can
  just use channelMapper